### PR TITLE
MD5 hash is not FIPS compliant, changed to SHA512

### DIFF
--- a/src/Snork.FluentNHibernateTools/SessionFactoryBuilder.cs
+++ b/src/Snork.FluentNHibernateTools/SessionFactoryBuilder.cs
@@ -17,16 +17,16 @@ namespace Snork.FluentNHibernateTools
         private static readonly Dictionary<string, SessionFactoryInfo> SessionFactoryInfos =
             new Dictionary<string, SessionFactoryInfo>();
 
-        private static string CalculateMD5Hash(string input)
+        private static string CalculateSHA512Hash(string input)
 
         {
-            // step 1, calculate MD5 hash from input
+            // step 1, calculate Sha512 hash from input
 
-            var md5 = MD5.Create();
+            var sha512 = SHA512.Create();
 
             var inputBytes = Encoding.ASCII.GetBytes(input);
 
-            var hash = md5.ComputeHash(inputBytes);
+            var hash = sha512.ComputeHash(inputBytes);
 
             // step 2, convert byte array to hex string
 
@@ -75,7 +75,7 @@ namespace Snork.FluentNHibernateTools
             KeyInfo keyInfo,
             ProviderTypeEnum providerType, Func<ConfigurationInfo> configFunc)
         {
-            var key = CalculateMD5Hash(new JavaScriptSerializer().Serialize(keyInfo));
+            var key = CalculateSHA512Hash(new JavaScriptSerializer().Serialize(keyInfo));
 
             lock (Mutex)
             {


### PR DESCRIPTION
MD5 hashes fail security scans at my job and the server blocks them from occurring.  SHA512 should work and pass security.  I would love an updated NuGet package too.  Currently I must replace script the build to replace the dll.